### PR TITLE
Make additional field optional in entity pallet

### DIFF
--- a/origin/container/entity/src/entity.rs
+++ b/origin/container/entity/src/entity.rs
@@ -100,13 +100,13 @@ pub struct IdentityInfo<FieldLimit: Get<u32>> {
 	/// A content identifier (CID) for a profile blob or document.
 	pub profile: Option<ProfileCid>,
 	/// Additional arbitrary (key, value) pairs.
-	pub additional: BoundedVec<(Attribute, Data), FieldLimit>,
+       pub additional: Option<BoundedVec<(Attribute, Data), FieldLimit>>,
 }
 
 impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
-	pub fn set_additional(&mut self, add: BoundedVec<(Attribute, Data), FieldLimit>) {
-		self.additional = add;
-	}
+       pub fn set_additional(&mut self, add: Option<BoundedVec<(Attribute, Data), FieldLimit>>) {
+               self.additional = add;
+       }
 }
 
 impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInfo<FieldLimit> {
@@ -118,9 +118,9 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 		self.fields().bits() & fields == fields
 	}
 
-	fn additional(&self) -> &BoundedVec<(Attribute, Data), FieldLimit> {
-		&self.additional
-	}
+       fn additional(&self) -> Option<&BoundedVec<(Attribute, Data), FieldLimit>> {
+               self.additional.as_ref()
+       }
 
 	fn apply_update(&mut self, op: &Self::UpdateOp) -> Result<(), IdentityUpdateError> {
 		match op {
@@ -141,38 +141,50 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 				Ok(())
 			},
 
-			IdentityUpdateOp::AddAdditional(key, val) => {
-				if self.additional.iter().any(|(k, _)| k == key) {
-					return Err(IdentityUpdateError::AttributeExists);
-				}
-				self.additional
-					.try_push((key.clone(), val.clone()))
-					.map_err(|_| IdentityUpdateError::TooManyAttributes)?;
-				Ok(())
-			},
+                       IdentityUpdateOp::AddAdditional(key, val) => {
+                               let additional = self.additional.get_or_insert_with(BoundedVec::default);
+                               if additional.iter().any(|(k, _)| k == key) {
+                                       return Err(IdentityUpdateError::AttributeExists);
+                               }
+                               additional
+                                       .try_push((key.clone(), val.clone()))
+                                       .map_err(|_| IdentityUpdateError::TooManyAttributes)?;
+                               Ok(())
+                       },
 
-			IdentityUpdateOp::UpdateAdditional(key, val) => {
-				if let Some((_, v)) = self.additional.iter_mut().find(|(k, _)| k == key) {
-					*v = val.clone();
-					Ok(())
-				} else {
-					Err(IdentityUpdateError::AttributeNotFound)
-				}
-			},
+                       IdentityUpdateOp::UpdateAdditional(key, val) => {
+                               if let Some(additional) = self.additional.as_mut() {
+                                       if let Some((_, v)) = additional.iter_mut().find(|(k, _)| k == key) {
+                                               *v = val.clone();
+                                               Ok(())
+                                       } else {
+                                               Err(IdentityUpdateError::AttributeNotFound)
+                                       }
+                               } else {
+                                       Err(IdentityUpdateError::AttributeNotFound)
+                               }
+                       },
 
-			IdentityUpdateOp::RemoveAdditional(key) => {
-				if let Some(i) = self.additional.iter().position(|(k, _)| k == key) {
-					self.additional.swap_remove(i);
-					Ok(())
-				} else {
-					Err(IdentityUpdateError::AttributeNotFound)
-				}
-			},
+                       IdentityUpdateOp::RemoveAdditional(key) => {
+                               if let Some(additional) = self.additional.as_mut() {
+                                       if let Some(i) = additional.iter().position(|(k, _)| k == key) {
+                                               additional.swap_remove(i);
+                                               if additional.is_empty() {
+                                                       self.additional = None;
+                                               }
+                                               Ok(())
+                                       } else {
+                                               Err(IdentityUpdateError::AttributeNotFound)
+                                       }
+                               } else {
+                                       Err(IdentityUpdateError::AttributeNotFound)
+                               }
+                       },
 
-			IdentityUpdateOp::ClearAdditional => {
-				self.additional.clear();
-				Ok(())
-			},
+                       IdentityUpdateOp::ClearAdditional => {
+                               self.additional = None;
+                               Ok(())
+                       },
 		}
 	}
 
@@ -190,7 +202,7 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 			legal: d.clone(),
 			web: d.clone(),
 			profile: Some(ProfileCid([0u8; 64])),
-			additional: additional.try_into().unwrap(),
+                       additional: Some(additional.try_into().unwrap()),
 		}
 	}
 
@@ -206,10 +218,10 @@ impl<FieldLimit: Get<u32>> Default for IdentityInfo<FieldLimit> {
 			display: Data::None,
 			legal: Data::None,
 			web: Data::None,
-			profile: None,
-			additional: BoundedVec::default(),
-		}
-	}
+                       profile: None,
+                       additional: None,
+               }
+       }
 }
 
 impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
@@ -227,9 +239,13 @@ impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
 		if self.profile.is_some() {
 			bits.insert(IdentityField::Profile);
 		}
-		if !self.additional.is_empty() {
-			bits.insert(IdentityField::Additional);
-		}
+               if self
+                       .additional
+                       .as_ref()
+                       .map_or(false, |a| !a.is_empty())
+               {
+                       bits.insert(IdentityField::Additional);
+               }
 		bits
 	}
 }

--- a/pallets/entity/src/identity.rs
+++ b/pallets/entity/src/identity.rs
@@ -79,14 +79,14 @@ pub struct IdentityInfo<FieldLimit: Get<u32>> {
 	pub web: Data,
 	/// A content identifier (CID) for a profile blob or document.
 	pub profile: Option<ProfileCid>,
-	/// Additional arbitrary (key, value) pairs.
-	pub additional: BoundedVec<(Attribute, Data), FieldLimit>,
+       /// Additional arbitrary (key, value) pairs.
+       pub additional: Option<BoundedVec<(Attribute, Data), FieldLimit>>,
 }
 
 impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
-	pub fn set_additional(&mut self, add: BoundedVec<(Attribute, Data), FieldLimit>) {
-		self.additional = add;
-	}
+       pub fn set_additional(&mut self, add: Option<BoundedVec<(Attribute, Data), FieldLimit>>) {
+               self.additional = add;
+       }
 }
 
 impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInfo<FieldLimit> {
@@ -98,9 +98,9 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 		self.fields().bits() & fields == fields
 	}
 
-	fn additional(&self) -> &BoundedVec<(Attribute, Data), FieldLimit> {
-		&self.additional
-	}
+       fn additional(&self) -> Option<&BoundedVec<(Attribute, Data), FieldLimit>> {
+               self.additional.as_ref()
+       }
 
 	fn apply_update(&mut self, op: &Self::UpdateOp) -> Result<(), IdentityUpdateError> {
 		match op {
@@ -121,38 +121,50 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 				Ok(())
 			},
 
-			IdentityUpdateOp::AddAdditional(key, val) => {
-				if self.additional.iter().any(|(k, _)| k == key) {
-					return Err(IdentityUpdateError::AttributeExists);
-				}
-				self.additional
-					.try_push((key.clone(), val.clone()))
-					.map_err(|_| IdentityUpdateError::TooManyAttributes)?;
-				Ok(())
-			},
+                       IdentityUpdateOp::AddAdditional(key, val) => {
+                               let additional = self.additional.get_or_insert_with(BoundedVec::default);
+                               if additional.iter().any(|(k, _)| k == key) {
+                                       return Err(IdentityUpdateError::AttributeExists);
+                               }
+                               additional
+                                       .try_push((key.clone(), val.clone()))
+                                       .map_err(|_| IdentityUpdateError::TooManyAttributes)?;
+                               Ok(())
+                       },
 
-			IdentityUpdateOp::UpdateAdditional(key, val) => {
-				if let Some((_, v)) = self.additional.iter_mut().find(|(k, _)| k == key) {
-					*v = val.clone();
-					Ok(())
-				} else {
-					Err(IdentityUpdateError::AttributeNotFound)
-				}
-			},
+                       IdentityUpdateOp::UpdateAdditional(key, val) => {
+                               if let Some(additional) = self.additional.as_mut() {
+                                       if let Some((_, v)) = additional.iter_mut().find(|(k, _)| k == key) {
+                                               *v = val.clone();
+                                               Ok(())
+                                       } else {
+                                               Err(IdentityUpdateError::AttributeNotFound)
+                                       }
+                               } else {
+                                       Err(IdentityUpdateError::AttributeNotFound)
+                               }
+                       },
 
-			IdentityUpdateOp::RemoveAdditional(key) => {
-				if let Some(i) = self.additional.iter().position(|(k, _)| k == key) {
-					self.additional.swap_remove(i);
-					Ok(())
-				} else {
-					Err(IdentityUpdateError::AttributeNotFound)
-				}
-			},
+                       IdentityUpdateOp::RemoveAdditional(key) => {
+                               if let Some(additional) = self.additional.as_mut() {
+                                       if let Some(i) = additional.iter().position(|(k, _)| k == key) {
+                                               additional.swap_remove(i);
+                                               if additional.is_empty() {
+                                                       self.additional = None;
+                                               }
+                                               Ok(())
+                                       } else {
+                                               Err(IdentityUpdateError::AttributeNotFound)
+                                       }
+                               } else {
+                                       Err(IdentityUpdateError::AttributeNotFound)
+                               }
+                       },
 
-			IdentityUpdateOp::ClearAdditional => {
-				self.additional.clear();
-				Ok(())
-			},
+                       IdentityUpdateOp::ClearAdditional => {
+                               self.additional = None;
+                               Ok(())
+                       },
 		}
 	}
 
@@ -170,7 +182,7 @@ impl<FieldLimit: Get<u32> + 'static> IdentityInformationProvider for IdentityInf
 			legal: d.clone(),
 			web: d.clone(),
 			profile: Some(ProfileCid([0u8; 64])),
-			additional: additional.try_into().unwrap(),
+                       additional: Some(additional.try_into().unwrap()),
 		}
 	}
 
@@ -186,10 +198,10 @@ impl<FieldLimit: Get<u32>> Default for IdentityInfo<FieldLimit> {
 			display: Data::None,
 			legal: Data::None,
 			web: Data::None,
-			profile: None,
-			additional: BoundedVec::default(),
-		}
-	}
+                       profile: None,
+                       additional: None,
+                }
+        }
 }
 
 impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
@@ -207,9 +219,13 @@ impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
 		if self.profile.is_some() {
 			bits.insert(IdentityField::Profile);
 		}
-		if !self.additional.is_empty() {
-			bits.insert(IdentityField::Additional);
-		}
+               if self
+                       .additional
+                       .as_ref()
+                       .map_or(false, |a| !a.is_empty())
+               {
+                       bits.insert(IdentityField::Additional);
+               }
 		bits
 	}
 }

--- a/pallets/entity/src/lib.rs
+++ b/pallets/entity/src/lib.rs
@@ -281,21 +281,21 @@ pub mod pallet {
 				Error::<T>::IdentifierSubAccount
 			);
 
-			let info: T::IdentityInformation = *info;
-			let additional = info.additional();
-
-			if !additional.is_empty() {
-				let mut seen = Vec::with_capacity(additional.len());
-				for (key, _val) in additional.iter() {
-					ensure!(!key.is_empty(), Error::<T>::InvalidAttributeEntry);
-					let raw_key = key.as_ref();
-					ensure!(
-						!seen.iter().any(|existing: &&[u8]| *existing == raw_key),
-						Error::<T>::DuplicateAttributeKey
-					);
-					seen.push(raw_key);
-				}
-			}
+                       let info: T::IdentityInformation = *info;
+                       if let Some(additional) = info.additional() {
+                               if !additional.is_empty() {
+                                       let mut seen = Vec::with_capacity(additional.len());
+                                       for (key, _val) in additional.iter() {
+                                               ensure!(!key.is_empty(), Error::<T>::InvalidAttributeEntry);
+                                               let raw_key = key.as_ref();
+                                               ensure!(
+                                                       !seen.iter().any(|existing: &&[u8]| *existing == raw_key),
+                                                       Error::<T>::DuplicateAttributeKey
+                                               );
+                                               seen.push(raw_key);
+                                       }
+                               }
+                       }
 
 			// let digest = T::Hashing::hash(&who.encode());
 			let digest = T::Hashing::hash(&(info.clone(), b"IdentityInfoSet".to_vec()).encode());
@@ -335,17 +335,19 @@ pub mod pallet {
 			IdentityOf::<T>::try_mutate(&id, |opt| -> DispatchResult {
 				let info = opt.as_mut().ok_or(Error::<T>::IdentifierNotFound)?;
 				let mut history = Vec::new();
-				for op in ops.iter() {
-					if let IdentityUpdateOp::UpdateAdditional(key, _) = op {
-						if let Some((_, old)) = info.additional().iter().find(|(k, _)| k == key) {
-							history.push((key.clone(), old.clone()));
-						}
-					}
-					info.apply_update(op).map_err(|e| match e {
-						IdentityUpdateError::AttributeExists => Error::<T>::AttributeExists,
-						IdentityUpdateError::TooManyAttributes => Error::<T>::TooManyAttributes,
-						IdentityUpdateError::AttributeNotFound => Error::<T>::AttributeNotFound,
-					})?;
+                               for op in ops.iter() {
+                                       if let IdentityUpdateOp::UpdateAdditional(key, _) = op {
+                                               if let Some(additional) = info.additional() {
+                                                       if let Some((_, old)) = additional.iter().find(|(k, _)| k == key) {
+                                                               history.push((key.clone(), old.clone()));
+                                                       }
+                                               }
+                                       }
+                                       info.apply_update(op).map_err(|e| match e {
+                                               IdentityUpdateError::AttributeExists => Error::<T>::AttributeExists,
+                                               IdentityUpdateError::TooManyAttributes => Error::<T>::TooManyAttributes,
+                                               IdentityUpdateError::AttributeNotFound => Error::<T>::AttributeNotFound,
+                                       })?;
 				}
 				for (key, old) in history {
 					let ver = Ss58OfAttributeVersion::<T>::get(&id, &key).saturating_add(1);

--- a/pallets/entity/src/tests.rs
+++ b/pallets/entity/src/tests.rs
@@ -73,12 +73,18 @@ fn full_identity_info_roundtrip_and_has_identity_bits() {
 		info.legal = plain_data(b"Legal Name, Esq.");
 		info.web = plain_data(b"https://example.com");
 		info.profile = Some(ProfileCid([0u8; 64]));
-		for i in 0..MaxAdditionalFields::get() {
-			let key = vec![b'k', i as u8];
-			let attr: Attribute = key.clone().try_into().unwrap();
-			let val = plain_data(&[i as u8]);
-			info.additional.try_push((attr, val)).unwrap();
-		}
+                info.additional = Some(BoundedVec::default());
+                for i in 0..MaxAdditionalFields::get() {
+                        let key = vec![b'k', i as u8];
+                        let attr: Attribute = key.clone().try_into().unwrap();
+                        let val = plain_data(&[i as u8]);
+                        info
+                                .additional
+                                .as_mut()
+                                .unwrap()
+                                .try_push((attr, val))
+                                .unwrap();
+                }
 
 		let who = account(12);
 		assert_ok!(Entity::set_identity(
@@ -154,13 +160,24 @@ fn set_identity_errors_and_edge() {
 
 		// 2. Duplicate additional key → DuplicateAttributeKey
 		//    Build an info with two entries using the same key.
-		let mut info_dup = IdentityInfo::<MaxAdditionalFields>::default();
-		// Need at least one non‐empty field so the pallet proceeds to the additional‐check
-		info_dup.display = plain_data(b"d");
-		let k = b"dup".to_vec();
-		let attr: Attribute = k.clone().try_into().unwrap();
-		info_dup.additional.try_push((attr.clone(), plain_data(b"v1"))).unwrap();
-		info_dup.additional.try_push((attr.clone(), plain_data(b"v2"))).unwrap();
+                let mut info_dup = IdentityInfo::<MaxAdditionalFields>::default();
+                // Need at least one non‐empty field so the pallet proceeds to the additional‐check
+                info_dup.display = plain_data(b"d");
+                let k = b"dup".to_vec();
+                let attr: Attribute = k.clone().try_into().unwrap();
+                info_dup.additional = Some(BoundedVec::default());
+                info_dup
+                        .additional
+                        .as_mut()
+                        .unwrap()
+                        .try_push((attr.clone(), plain_data(b"v1")))
+                        .unwrap();
+                info_dup
+                        .additional
+                        .as_mut()
+                        .unwrap()
+                        .try_push((attr.clone(), plain_data(b"v2")))
+                        .unwrap();
 		assert_noop!(
 			Entity::set_identity(RuntimeOrigin::signed(who.clone()), Box::new(info_dup)),
 			Error::<Test>::DuplicateAttributeKey
@@ -203,9 +220,14 @@ fn set_identity_empty_additional_key_errors() {
 	new_test_ext().execute_with(|| {
 		let who = account(50);
 		// Start with a “default” info and then hack in a single empty‐key entry.
-		let mut bad = IdentityInfo::<MaxAdditionalFields>::default();
-		let empty_attr: Attribute = Vec::new().try_into().unwrap(); // length 0 is allowed by TryFrom
-		bad.additional.try_push((empty_attr.clone(), plain_data(b"v"))).unwrap();
+                let mut bad = IdentityInfo::<MaxAdditionalFields>::default();
+                let empty_attr: Attribute = Vec::new().try_into().unwrap(); // length 0 is allowed by TryFrom
+                bad.additional = Some(BoundedVec::default());
+                bad.additional
+                        .as_mut()
+                        .unwrap()
+                        .try_push((empty_attr.clone(), plain_data(b"v")))
+                        .unwrap();
 
 		// That should trigger our ensure!(!key.is_empty(), Error::InvalidAttributeEntry)
 		assert_noop!(
@@ -349,10 +371,11 @@ fn add_attribute_positive() {
 		// stored in IdentityOf
 		let id = Ss58OfActiveAccounts::<Test>::get(&who).unwrap();
 		let info = IdentityOf::<Test>::get(&id).unwrap();
-		assert!(info
-			.additional()
-			.iter()
-			.any(|(attr, data)| &attr[..] == &key[..] && data == &val));
+                assert!(info
+                        .additional()
+                        .unwrap()
+                        .iter()
+                        .any(|(attr, data)| &attr[..] == &key[..] && data == &val));
 	});
 }
 
@@ -489,7 +512,7 @@ fn add_attribute_capacity_via_update_and_exhaust() {
 
 		// Verify that stored IdentityInfo.additional.len() == MaxAdditionalFields:
 		let stored = IdentityOf::<Test>::get(&id).unwrap();
-		assert_eq!(stored.additional().len() as u32, MaxAdditionalFields::get());
+                assert_eq!(stored.additional().map(|a| a.len() as u32).unwrap_or(0), MaxAdditionalFields::get());
 	});
 }
 

--- a/pallets/entity/src/types.rs
+++ b/pallets/entity/src/types.rs
@@ -88,8 +88,8 @@ pub trait IdentityInformationProvider:
 	/// extra `(Data,Data)` pairs we can hold
 	type FieldLimit: Get<u32>;
 
-	/// additional entries
-	fn additional(&self) -> &BoundedVec<(Attribute, Data), Self::FieldLimit>;
+       /// additional entries, if any
+       fn additional(&self) -> Option<&BoundedVec<(Attribute, Data), Self::FieldLimit>>;
 
 	/// Does `self` actually have data for *all* the bits flipped in `fields`?
 	fn has_identity(&self, fields: Self::FieldsIdentifier) -> bool;


### PR DESCRIPTION
## Summary
- make `additional` optional in `IdentityInfo`
- handle `Option` in update logic
- update runtime entity implementation
- adjust tests for optional `additional`